### PR TITLE
Related Content Type Fix

### DIFF
--- a/src/Converter/JSONAPIConverter.php
+++ b/src/Converter/JSONAPIConverter.php
@@ -50,7 +50,11 @@ class JSONAPIConverter
 
         if (! $this->isSearch($parameters)) {
             //Get content type if it isn't a search...
-            $parameters['contentType'] = $request->attributes->get('contentType');
+            $parameters['contentType'] = $request->attributes->get('relatedContentType');
+
+            if (! $parameters['contentType']) {
+                $parameters['contentType'] = $request->attributes->get('contentType');
+            }
         }
 
         $parameters['page']['size'] = $request->query->get('page[size]', false, true);


### PR DESCRIPTION
When displaying related content types like `/json/showcases/1/pages`, it would display incorrectly. This should fix the problem in the future.
