### PR TITLE
Query parser Fix #34

### DIFF
--- a/src/Provider/APIProvider.php
+++ b/src/Provider/APIProvider.php
@@ -14,6 +14,8 @@ use Bolt\Extension\Bolt\JsonApi\Storage\Query\Handler\Directive\PagerHandler;
 use Bolt\Extension\Bolt\JsonApi\Storage\Query\Handler\PagingHandler;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Bolt\Storage\Query\ContentQueryParser;
+
 
 /**
  * Class APIProvider
@@ -152,9 +154,13 @@ class APIProvider implements ServiceProviderInterface
             }
         );
 
-        $app['query.parser']->addDirectiveHandler('paginate', new PagerHandler());
-        $app['query.parser']->addHandler('pager', new PagingHandler());
-        $app['query.parser']->addOperation('pager');
+        $app->extend('query.parser', function (ContentQueryParser $parser) {
+            $parser->addDirectiveHandler('paginate', new PagerHandler());
+            $parser->addHandler('pager', new PagingHandler());
+            $parser->addOperation('pager');
+
+            return $parser;
+        });
     }
 
     /**


### PR DESCRIPTION
The Bolt core updated how the `ContentQueryParser` was registered as a service. Since the update, it now uses a fresh instance of the `ContentQueryParser` class. This broke functionality with the extension by not including the Paging handlers and directives. It is now fixed with this PR. Closes - https://github.com/xiaohutai/jsonapi/issues/34