### PR TITLE
Fix "Notice: Undefined variable: fieldType" when not defining a slug

### DIFF
--- a/src/Parser/Field/FieldFactory.php
+++ b/src/Parser/Field/FieldFactory.php
@@ -91,7 +91,7 @@ class FieldFactory
             } elseif ($data instanceof Carbon) {
                 $type = new Date($field, $data, $config);
             } elseif (!$data instanceof LazyCollection) {
-                if (in_array($fieldType, self::$fileTypes)) {
+                if (($fieldType !== null) && in_array($fieldType, self::$fileTypes)) {
                     $type = new File($field, $data, $resourceManager, $config);
                     $type->setFieldType($fieldType);
                 } else {

--- a/src/Parser/Field/FieldFactory.php
+++ b/src/Parser/Field/FieldFactory.php
@@ -53,10 +53,10 @@ class FieldFactory
                 $fieldType = $field;
             } else {
                 $data = $item->get($field);
-                if (isset($metadata['fields'])) {
-                    if (isset($metadata['fields'][$field]) && isset($metadata['fields'][$field]['data']['type'])) {
-                        $fieldType = $metadata['fields'][$field]['data']['type'];
-                    }
+                if (isset($metadata['fields'][$field]['data']['type'])) {
+                    $fieldType = $metadata['fields'][$field]['data']['type'];
+                } else {
+                    $fieldType = null;
                 }
             }
 


### PR DESCRIPTION
If I have a content type without explicitly defining a "slug" field I've got this error:

"Notice: Undefined variable: fieldType" in FieldFactory on line 94.

This PR should fix it.