### PR TITLE
[WIP] Fix for supporting Blocks field

### DIFF
--- a/src/Parser/Field/Type/RepeatingCollection.php
+++ b/src/Parser/Field/Type/RepeatingCollection.php
@@ -61,6 +61,7 @@ class RepeatingCollection extends ArrayCollection implements TypeInterface
                     $attributes[$field->getType()] = $field->render();
                 }
                 $multidimensional[] = $attributes;
+                $attributes = null;
             }
         }
 


### PR DESCRIPTION
This solution is simply working by resetting the attributes table at each iteration.
It should not affect the display of the repeating field but as blocks have named sets of fields it should be better to have structure like : 

```
"blocks_field" : [ "set-1": ["image", "caption"], "set-2": ["text", "image-list"] ]
```

instead of :
```
"blocks_field" : [  {"image", "caption"}, {"text", "image-list"} ]
```
