### PR TITLE
Return empty lists with status 200 instead of 400 - Fix for issue #70

### DIFF
--- a/src/Action/ContentListAction.php
+++ b/src/Action/ContentListAction.php
@@ -35,8 +35,6 @@ class ContentListAction extends FetchAction
 
         $results = $set->get($contentType);
 
-        $this->throwErrorOnNoResults($results, 'Bad request: There were no results based upon your criteria!');
-
         $included = $this->fetchIncludes(
             $parameters->getParametersByType('includes'),
             $results,

--- a/src/Action/FetchAction.php
+++ b/src/Action/FetchAction.php
@@ -4,7 +4,6 @@ namespace Bolt\Extension\Bolt\JsonApi\Action;
 
 use Bolt\Extension\Bolt\JsonApi\Config\Config;
 use Bolt\Extension\Bolt\JsonApi\Converter\Parameter\Type\Fields;
-use Bolt\Extension\Bolt\JsonApi\Exception\ApiInvalidRequestException;
 use Bolt\Extension\Bolt\JsonApi\Helpers\DataLinks;
 use Bolt\Extension\Bolt\JsonApi\Parser\Parser;
 use Bolt\Storage\Entity\Content;
@@ -42,19 +41,6 @@ class FetchAction
         $this->parser = $parser;
         $this->dataLinks = $dataLinks;
         $this->config = $config;
-    }
-
-    /**
-     * @param $results
-     * @param $message
-     */
-    protected function throwErrorOnNoResults($results, $message)
-    {
-        if (! $results || (is_array($results) && count($results) === 0)) {
-            throw new ApiInvalidRequestException(
-                $message
-            );
-        }
     }
 
     /**

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -54,8 +54,6 @@ class SearchAction extends FetchAction
 
         $page = $parameters->getParametersByType('page');
 
-        $this->throwErrorOnNoResults($results, "No search results found for query [$search]");
-
         foreach ($results as $key => $item) {
             // optimize this part...
             $fields = $parameters->get('fields')->getFields();

--- a/src/Action/SingleAction.php
+++ b/src/Action/SingleAction.php
@@ -41,8 +41,10 @@ class SingleAction extends FetchAction
         /** @var Content $results */
         $results = $this->query->getContent($contentType, $queryParameters);
 
-        $this->throwErrorOnNoResults($results, "No [$contentType] found with id/slug: [$slug].");
-
+        if (! $results) {
+            throw new ApiNotFoundException("No [$contentType] found with id/slug: [$slug].");
+        }
+ 
         if ($relatedContentType !== null) {
             $relatedItemsTotal = $results->getRelation($relatedContentType)->count();
             if ($relatedItemsTotal <= 0) {


### PR DESCRIPTION
If the response to a request is an empty list, return that empty list with status 200, instead of 400.
Fixes issue #70.

Removed method throwErrorOnNoResults, as it would be used only in SingleAction.php (for retrieving a single record).  Changed the status code from 400 to 404 for the response if this record does not exist, according to http://jsonapi.org/format/#fetching-resources-responses.