### PR TITLE
Set correct response header for `menu` and `taxonomy`

### DIFF
--- a/src/Action/MenuAction.php
+++ b/src/Action/MenuAction.php
@@ -44,15 +44,19 @@ class MenuAction
         }
 
         $menu = $this->boltConfig->get('menu' . $name, false);
-        
+
         if (! $menu) {
             throw new ApiNotFoundException(
                 "Menu with name [$name] not found."
             );
         }
 
-        return new ApiResponse([
+        $response = new ApiResponse([
             'data' => $menu,
         ], $this->extensionConfig);
+
+        $response->headers->set('Content-Type', 'application/json');
+
+        return $response;
     }
 }

--- a/src/Action/TaxonomyAction.php
+++ b/src/Action/TaxonomyAction.php
@@ -51,8 +51,12 @@ class TaxonomyAction
             );
         }
 
-        return new ApiResponse([
+        $response = new ApiResponse([
             'data' => $taxonomy,
         ], $this->extensionConfig);
+
+        $response->headers->set('Content-Type', 'application/json');
+
+        return $response;
     }
 }


### PR DESCRIPTION
Since these two actions are not JSON API (e.g. `application/vnd.api+json)`, we set them to `application/json` for now. The problem is that responses need to be written which will cause a bigger break. This is in a separate pull request #86 and for a newer version later.